### PR TITLE
Extend roadmap phases

### DIFF
--- a/DEVELOPMENT_ROADMAP.md
+++ b/DEVELOPMENT_ROADMAP.md
@@ -47,6 +47,11 @@ Legend 🟢 done 🟡 in progress 🔴 not started
 | **3** | Voting / Polling engine, live result feed (WebSockets) | 🔴 |
 | **4** | Scorecards & KPI dashboards | 🔴 |
 | **5** | Hardening, docs, 80 % test coverage, CI/CD to staging | 🟡 in progress |
+| **6** | Beta feedback & polish | 🔴 |
+| **7** | Multi-co-op tenancy | 🔴 |
+| **8** | Maintenance & assets | 🔴 |
+| **9** | Finance integration | 🔴 |
+| **10** | Extensions & community | 🔴 |
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Phase 4   Analytics               🔴
 Phase 5   File Uploads            🔴
 Phase 6   Notifications           🔴
 Phase 7   Hardening & Deployment  🔴
+Phase 8   Beta Feedback & Polish  🔴
+Phase 9   Multi-Co-op Tenancy     🔴
+Phase 10  Maintenance & Assets    🔴
+Phase 11  Finance Integration     🔴
+Phase 12  Extensions & Community  🔴
 
 5 Module Layout (monorepo)
 --------------------------

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,5 +14,10 @@
 - Phase 5: File Uploads (🔴)
 - Phase 6: Notifications (🔴)
 - Phase 7: Hardening & Deployment (🔴)
+- Phase 8: Beta Feedback & Polish (🔴)
+- Phase 9: Multi-Co-op Tenancy (🔴)
+- Phase 10: Maintenance & Assets (🔴)
+- Phase 11: Finance Integration (🔴)
+- Phase 12: Extensions & Community (🔴)
  
 For detailed milestones and work items, see `ROADMAP_REBOOT.md` and `DEVELOPMENT_ROADMAP.md`.

--- a/ROADMAP_REBOOT.md
+++ b/ROADMAP_REBOOT.md
@@ -154,5 +154,71 @@ From the post‑mortem we learned that file uploads were entirely absent【F:OUT
 - CI pipeline builds, tests, and deploys automatically.
 - Documentation complete and reviewed.
 
+## Phase 8 – Beta Feedback & Polish
+**Goal:** Release a minimal beta to select co-ops and gather feedback.
+
+**Tasks**
+1. Deploy a staging environment for early adopters with seed data.
+2. Enable error tracking (e.g. Sentry) and usage analytics.
+3. Collect feedback via in-app forms and track issues in GitHub.
+4. Prioritise bug fixes and usability improvements.
+5. Document onboarding steps and update README with known issues.
+
+**Checkpoint**
+- Beta testers actively use the system and submit feedback.
+- Major blockers addressed before wider launch.
+
+## Phase 9 – Multi-Co-op Tenancy
+**Goal:** Host multiple cooperatives on the same platform.
+
+**Tasks**
+1. Add a `Coop` tenant model and reference it from all entities.
+2. Update authentication and permissions to enforce tenant isolation.
+3. Extend API and UI to switch between co-ops.
+4. Migrate data and include fixtures for multi-coop demos.
+5. Provide a tenant-aware admin dashboard.
+
+**Checkpoint**
+- Data from different co-ops remains isolated and accessible only to authorised members.
+
+## Phase 10 – Maintenance & Asset Tracking
+**Goal:** Manage building assets and scheduled maintenance.
+
+**Tasks**
+1. Introduce `Asset` and `MaintenanceEvent` models with optional attachments.
+2. Calendar UI showing upcoming maintenance events.
+3. Reminder emails sent via Celery tasks.
+4. Reports summarising maintenance costs and history.
+5. Update documentation with examples and screenshots.
+
+**Checkpoint**
+- Maintenance events appear on the dashboard and reminders work in tests.
+
+## Phase 11 – Finance Integration
+**Goal:** Provide basic accounting and payment capabilities.
+
+**Tasks**
+1. Implement invoice and expense models with CRUD APIs.
+2. Integrate with a payment gateway for dues collection.
+3. Export financial reports to CSV or PDF.
+4. Add roles and permissions for treasurers.
+5. Document security considerations around financial data.
+
+**Checkpoint**
+- Dues payments recorded successfully and financial exports available.
+
+## Phase 12 – Extensions & Community
+**Goal:** Encourage community contributions and third-party integrations.
+
+**Tasks**
+1. Publish stable REST API endpoints with versioning.
+2. Define a plugin architecture and example extension repository.
+3. Provide contributor guide, code of conduct and governance policy.
+4. Automate dependency updates and set release cadence.
+5. Showcase at least one community-created plugin.
+
+**Checkpoint**
+- First external extension installed and documentation updated.
+
 ---
 By advancing through these phases sequentially and verifying each checkpoint, we ensure a stable foundation before tackling more complex features. This approach keeps the scope focused and allows visible progress after every milestone.


### PR DESCRIPTION
## Summary
- add new phases beyond the original roadmap in README
- list extended roadmap in ROADMAP.md
- expand ROADMAP_REBOOT.md with phases 8–12
- update DEVELOPMENT_ROADMAP table with additional phases

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843791edb788323b2860dceed6b27c4