### PR TITLE
Add demo reset endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Implemented Task model, CRUD API and tests.
 - Added Celery skeleton for due-date reminders.
 
+### Added
+- `/demo/reset` endpoint for recreating demo fixtures
+- Shared seeding logic for tests and local demo instances
+
 ## [0.1.0] - Initial Phase 1 Skeleton
 - Added backend FastAPI application with Member and Unit CRUD endpoints.
 - Added SQLite database setup with demo seed data.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ docker compose up --build
 
 The API is now on `http://localhost:8000` – open
 `http://localhost:8000/docs` for the Swagger UI. On first run the
-SQLite database will be created automatically with demo data.
+SQLite database will be created automatically with demo data. You can
+reset the demo fixtures at any time by calling `POST /demo/reset`.
 Run the React app from `frontend/` with:
 
 ```bash

--- a/backend/app/demo.py
+++ b/backend/app/demo.py
@@ -1,0 +1,36 @@
+from sqlalchemy.orm import Session
+
+from . import models
+from .db import Base, engine, SessionLocal
+
+
+def seed_demo_data(session: Session) -> None:
+    """Insert demo Units, Members and Tasks if tables are empty."""
+    if not session.query(models.Unit).first():
+        session.add_all([
+            models.Unit(name="101"),
+            models.Unit(name="102"),
+        ])
+        session.commit()
+
+    if not session.query(models.Member).first():
+        session.add_all([
+            models.Member(name="Alice", email="alice@example.com", unit_id=1),
+            models.Member(name="Bob", email="bob@example.com", unit_id=2),
+        ])
+        session.commit()
+
+    if not session.query(models.Task).first():
+        session.add_all([
+            models.Task(title="Paint hallway", assignee_id=1),
+            models.Task(title="Fix sink", assignee_id=2),
+        ])
+        session.commit()
+
+
+def reset_demo_db() -> None:
+    """Drop all tables and recreate them with demo data."""
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    with SessionLocal() as session:
+        seed_demo_data(session)

--- a/backend/tests/test_demo.py
+++ b/backend/tests/test_demo.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+
+from app.api import app, reset_demo_db
+
+# Ensure a clean DB for the test
+reset_demo_db()
+client = TestClient(app)
+
+
+def test_demo_reset_endpoint():
+    # Modify DB
+    client.post("/units/", json={"name": "999"})
+    # Reset using demo endpoint
+    r = client.post("/demo/reset")
+    assert r.status_code == 200
+
+    r = client.get("/units/")
+    names = [u["name"] for u in r.json()]
+    assert names == ["101", "102"]
+
+    r = client.get("/tasks/")
+    titles = [t["title"] for t in r.json()]
+    assert "Paint hallway" in titles and "Fix sink" in titles

--- a/backend/tests/test_members.py
+++ b/backend/tests/test_members.py
@@ -1,20 +1,19 @@
 from fastapi.testclient import TestClient
 
-from app.api import app, Base, engine
+from app.api import app, reset_demo_db
 
-Base.metadata.drop_all(bind=engine)
-Base.metadata.create_all(bind=engine)
+reset_demo_db()
 
 client = TestClient(app)
 
 def test_create_and_read_member():
     # create unit
-    r = client.post("/units/", json={"name": "101"})
+    r = client.post("/units/", json={"name": "999"})
     assert r.status_code == 200
     unit_id = r.json()["id"]
 
     # create member
-    r = client.post("/members/", json={"name": "Alice", "email": "alice@example.com", "unit_id": unit_id})
+    r = client.post("/members/", json={"name": "Charlie", "email": "charlie@example.com", "unit_id": unit_id})
     assert r.status_code == 200
     member_id = r.json()["id"]
 
@@ -28,12 +27,12 @@ def test_create_and_read_member():
     r = client.get(f"/members/{member_id}")
     assert r.status_code == 200
     data = r.json()
-    assert data["email"] == "alice@example.com"
+    assert data["email"] == "charlie@example.com"
 
     # update member
-    r = client.put(f"/members/{member_id}", json={"name": "Alice B", "email": "alice.b@example.com", "unit_id": unit_id})
+    r = client.put(f"/members/{member_id}", json={"name": "Charlie B", "email": "charlie.b@example.com", "unit_id": unit_id})
     assert r.status_code == 200
-    assert r.json()["name"] == "Alice B"
+    assert r.json()["name"] == "Charlie B"
 
     # delete member
     r = client.delete(f"/members/{member_id}")

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -1,8 +1,7 @@
 from fastapi.testclient import TestClient
-from app.api import app, Base, engine
+from app.api import app, reset_demo_db
 
-Base.metadata.drop_all(bind=engine)
-Base.metadata.create_all(bind=engine)
+reset_demo_db()
 
 client = TestClient(app)
 

--- a/backend/tests/test_units.py
+++ b/backend/tests/test_units.py
@@ -1,9 +1,8 @@
 from fastapi.testclient import TestClient
 
-from app.api import app, Base, engine
+from app.api import app, reset_demo_db
 
-Base.metadata.drop_all(bind=engine)
-Base.metadata.create_all(bind=engine)
+reset_demo_db()
 
 client = TestClient(app)
 

--- a/codex_env_setup.md
+++ b/codex_env_setup.md
@@ -1,0 +1,19 @@
+# Environment Setup for the Demo
+
+Create a `.env` file in the project root with the following values if you want to run against PostgreSQL and enable Celery. The demo and tests default to SQLite so these are optional.
+
+```
+POSTGRES_HOST=postgres
+POSTGRES_DB=thecooperator
+POSTGRES_USER=tc_app
+POSTGRES_PASSWORD=super-secret
+JWT_SECRET=change-me
+CELERY_BROKER_URL=redis://redis:6379/0
+```
+
+Load the variables before starting the backend:
+
+```bash
+export $(grep -v '^#' .env | xargs)
+uvicorn app.api:app --reload
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,3 +39,37 @@ similar container orchestrator.
 
 See `ROADMAP_REBOOT.md` for the phased development plan and `README.md` for a
 quick overview of the project goals.
+
+## 5. Database Schema
+
+The backend currently uses **SQLAlchemy** models with **Alembic** migrations to
+manage schema updates.  During development an SQLite database is created
+automatically; production deployments target PostgreSQL.  Administrators can add
+or remove columns via new migration scripts.
+
+### Tables
+
+| Table       | Key | Fields & Notes                                                                |
+|-------------|-----|-------------------------------------------------------------------------------|
+| `units`     | `id` PK | `name` (unique)                                                            |
+| `members`   | `id` PK | `name`, `email` (unique), `unit_id` → `units.id`                           |
+| `tasks`     | `id` PK | `title`, `status` enum, `priority` enum, `due_date`, `assignee_id` → `members.id` |
+| `committees` *(planned)* | `id` PK | `name`, `description`                                         |
+
+### Relationships
+
+* **Unit → Member** – one unit may have many members. Members reference their
+  unit via `unit_id`.
+* **Member → Task** – tasks may optionally be assigned to a member via
+  `assignee_id`.
+* **Committee → Task** – future work will allow tasks to be linked to
+  committees, enabling group ownership.
+
+### Administration
+
+CRUD endpoints expose these tables so data can be created, updated or deleted
+through the API or a future admin UI.  When schema changes are required,
+administrators create Alembic migrations to alter the tables safely and keep
+environments in sync.
+For local demos and tests a helper endpoint `POST /demo/reset` drops all
+tables and re-inserts the default fixtures.


### PR DESCRIPTION
## Summary
- add reusable demo seed script and `/demo/reset` route
- document environment variables and demo reset
- use demo reset for tests

## Testing
- `pytest -q`
- `curl -s -X POST http://localhost:8001/demo/reset`

------
https://chatgpt.com/codex/tasks/task_e_6846344a9a1c83238c4ff1a80c3a0827